### PR TITLE
content应该放到http选项内

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ $client = new Roiwk\SSEClient\Client('http://127.0.0.1:8888', [
             'header' => [
                 'Content-Type: application/json',
             ],
+            'content' => json_encode(['test' => 1]),
         ],
-        'content' => json_encode(['test' => 1]),
     ],
 ]);
 


### PR DESCRIPTION
README文档高级用法示例，content应该放到http内，不然会报错：
Fatal error: Uncaught ValueError: Options should have the form ["wrappername"]["optionname"] = $value in /vendor/roiwk/sse-client/src/Client.php:139
